### PR TITLE
chore: add validations to skip exec if no layers are configured

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,11 @@ export default class GlobalLayers {
       excludedFuncs: [],
     };
 
+    if (layers.length == 0) {
+      this.logInfo("No global layers are configured");
+      return;
+    }
+
     service.getAllFunctions().forEach((name) => {
       if (excludedFuncs.includes(name)) {
         this.logInfo(
@@ -69,6 +74,11 @@ export default class GlobalLayers {
       layers: [],
       excludedFuncs: [],
     };
+
+    if (layers.length == 0) {
+      this.logInfo("No global layers are configured");
+      return;
+    }
 
     if (excludedFuncs.inlcudes(name)) {
       this.logInfo(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "serverless-plugin-global-layers",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "serverless-plugin-global-layers",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0"


### PR DESCRIPTION
## Description

Make validations to skip execution if no global layers are configured on serverless.yml

## Task Context

### What is the current behavior?

Plugin tries to add configuration but if not exist just load uneeded config

### What is the new behavior?

Finish plugin execution if there is no config found

### Additional Context

<!-- Add here any additional context you think is important. -->
