### PR TITLE
fix: some field is not present and gets undefined error

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,10 +27,15 @@ export default class GlobalLayers {
    */
   async addToAll() {
     const { service } = this.serverless;
-    const { layers, excludedFuncs } = service.custom.globalLayers || {
-      layers: [],
-      excludedFuncs: [],
-    };
+    let { layers, excludedFuncs } = service.custom.globalLayers;
+
+    if (!layers) {
+      layers = [];
+    }
+
+    if (!excludedFuncs) {
+      excludedFuncs = [];
+    }
 
     if (layers.length == 0) {
       this.logInfo("No global layers are configured");
@@ -70,10 +75,15 @@ export default class GlobalLayers {
     }
 
     const { service } = this.serverless;
-    const { layers, excludedFuncs } = service.custom.globalLayers || {
-      layers: [],
-      excludedFuncs: [],
-    };
+    let { layers, excludedFuncs } = service.custom.globalLayers;
+
+    if (!layers) {
+      layers = [];
+    }
+
+    if (!excludedFuncs) {
+      excludedFuncs = [];
+    }
 
     if (layers.length == 0) {
       this.logInfo("No global layers are configured");


### PR DESCRIPTION
## Description

Catch error when some configuration field is not present on serverless.yml

## Task Context

### What is the current behavior?

If some of the `layers` or `excludedFuncs` fields are not presetn plugin will try execute array functions over udefined varaibles and this throws an error.

### What is the new behavior?

if some of the fields are missing on configuration, this will be set to an empty array by default to avoid undefined error.

### Additional Context

<!-- Add here any additional context you think is important. -->
